### PR TITLE
CIF-885 - Automatically generate sample all package from archetype

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           name: Upload artifact to GitHub
           command: |
             ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete latest $ALL_PACKAGE
+            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete latest $ALL_PACKAGE
 
       - store_artifacts:
           path: ~/repo/venia-store/demo-store/all/target/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,9 +160,9 @@ workflows:
       - build-java-8
       - build-java-11
       - deploy-sample-all:
-          requires: # Only deploy after tests passed
+          requires:
             - build-java-8
             - build-java-11
-#          filters: # Upload artifact only on master
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
           command: |
             java -version
             mvn -v
-            mvn -B integration-test
+            mvn -B install
             mvn help:evaluate -Dexpression=project.version -q -DforceStdout > ~/version.txt
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
   deploy-all-package:
     description: "Generate sample project from archetype and deploy all package to GitHub release"
     parameters:
-      name:
+      release-name:
         type: string
         default: "Venia Demo Store Project"
     steps:
@@ -56,7 +56,7 @@ commands:
           name: Upload artifact to GitHub
           command: |
             ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
-            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n << parameters.name >> -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
+            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n << parameters.release-name >> -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
 
   build-archetype:
     description: "Build and verify archetype"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
           name: Upload artifact to GitHub
           command: |
             ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
-            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n << parameters.release-name >> -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
+            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n "<< parameters.release-name >>" -c ${CIRCLE_SHA1} -prerelease -delete ${RELEASE_VERSION} ${ALL_PACKAGE}
 
   build-archetype:
     description: "Build and verify archetype"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,43 +12,85 @@
 #
 ################################################################################
 
-# Java Maven CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-java/ for more details
-#
 version: 2
 
-shared: &shared
+shared_steps:
+  - &build_all_package
+    run: 
+      name: Build All Package
+      command: |
+        ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        mkdir -p venia-store
+        cd venia-store
+        mvn archetype:generate -B \
+          -DarchetypeGroupId="com.adobe.commerce.cif" \
+          -DarchetypeArtifactId="cif-project-archetype" \
+          -DarchetypeVersion=$ARCHETYPE_VERSION \
+          -DgroupId="com.venia.cif" \
+          -DartifactId="demo-store" \
+          -Dversion=1.0.0 \
+          -Dpackage="com.venia.cif" \
+          -DappsFolderName="venia" \
+          -DartifactName="Venia Demo Store" \
+          -DcontentFolderName="venia" \
+          -DpackageGroup="venia" \
+          -DsiteName="Venia Demo Store" \
+          -DoptionAemVersion=6.5.0 \
+          -DoptionIncludeExamples=y
+        cd demo-store
+        mvn clean package
+
+  - &install_ghr
+    run:
+      name: Install ghr
+      command: |
+        mkdir -p tmp
+        curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz -C ./tmp
+        mv tmp/**/ghr ./ghr
+        chmod +x ghr
+
+  - &deploy_github
+    run:
+      name: Upload artifact to GitHub
+      command: |
+        ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
+        ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
+
+  - &build_core_components
+    run:
+      name: Checkout and build CIF Core Components
+      command: |
+        git clone https://github.com/adobe/aem-core-cif-components.git
+        cd aem-core-cif-components
+        mvn -B clean install
+        cd ..
+        rm -rf aem-core-cif-components
+
+  - &build_archetype
+    run: 
+      name: Build Archetype
+      command: |
+        java -version
+        mvn -v
+        mvn -B integration-test
+
+shared_build: &shared_build
   working_directory: ~/repo
 
   environment:
-    # Customize the JVM maximum heap limit
     MAVEN_OPTS: -Xmx3200m
 
   steps:
     - checkout
 
-    # Download and cache dependencies
     - restore_cache:
         keys:
           - v1-dependencies-{{ checksum "pom.xml" }}
           - v1-dependencies-
 
-    - run:
-        name: Checkout and build CIF Core Components
-        command: |
-          git clone https://github.com/adobe/aem-core-cif-components.git
-          cd aem-core-cif-components
-          mvn -B clean install
-          cd ..
-          rm -rf aem-core-cif-components
+    - *build_core_components
 
-    - run: 
-        name: Build Archetype
-        command: |
-          java -version
-          mvn -v
-          mvn -B integration-test
+    - *build_archetype
 
     - save_cache:
         paths:
@@ -61,8 +103,10 @@ shared: &shared
           mkdir -p ~/test-results/junit/
           find . -type f -regex ".*/surefire-reports/.*" -exec cp {} ~/test-results/junit/ \;
         when: always
+
     - store_test_results:
         path: ~/test-results
+
     - store_artifacts:
         path: ~/test-results/junit
 
@@ -70,85 +114,36 @@ jobs:
   build-java-8:
     docker:
       - image: circleci/openjdk:8u212-jdk-stretch
-    <<: *shared
+    <<: *shared_build
 
   build-java-11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
-    <<: *shared
-  
+    <<: *shared_build
+
   build-sample-all:
-    working_directory: ~/repo
-
-    environment:
-      # Customize the JVM maximum heap limit
-      MAVEN_OPTS: -Xmx3200m
-
     docker:
       - image: circleci/openjdk:11-jdk-stretch
 
+    working_directory: ~/repo
+
+    environment:
+      MAVEN_OPTS: -Xmx3200m
+      RELEASE_VERSION: latest
+
     steps:
       - checkout
+
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "pom.xml" }}
             - v1-dependencies-
 
-      - run:
-          name: Checkout and build CIF Core Components
-          command: |
-            git clone https://github.com/adobe/aem-core-cif-components.git
-            cd aem-core-cif-components
-            mvn -B clean install
-            cd ..
-            rm -rf aem-core-cif-components
-
-      - run: 
-          name: Build Archetype
-          command: |
-            mvn -B clean install
-
-      - run: 
-          name: Build All Package
-          command: |
-            ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-            mkdir -p venia-store
-            cd venia-store
-            mvn archetype:generate -B \
-              -DarchetypeGroupId="com.adobe.commerce.cif" \
-              -DarchetypeArtifactId="cif-project-archetype" \
-              -DarchetypeVersion=$ARCHETYPE_VERSION \
-              -DgroupId="com.venia.cif" \
-              -DartifactId="demo-store" \
-              -Dversion=$ARCHETYPE_VERSION \
-              -Dpackage="com.venia.cif" \
-              -DappsFolderName="venia" \
-              -DartifactName="Venia Demo Store" \
-              -DcontentFolderName="venia" \
-              -DpackageGroup="venia" \
-              -DsiteName="Venia Demo Store" \
-              -DoptionAemVersion=6.5.0 \
-              -DoptionIncludeExamples=y
-            cd demo-store
-            mvn clean package
-
-      - run:
-          name: Install GHR
-          command: |
-            mkdir -p tmp
-            curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz -C ./tmp
-            mv tmp/**/ghr ./ghr
-            chmod +x ghr
-
-      - run:
-          name: Upload artifact to GitHub
-          command: |
-            ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
-            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete latest $ALL_PACKAGE
-
-      - store_artifacts:
-          path: ~/repo/venia-store/demo-store/all/target/
-          destination: venia-store
+      - *build_core_components
+      - *build_archetype
+      - *build_all_package
+      - *install_ghr
+      - *deploy_github
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ shared_steps:
           -DarchetypeVersion=$ARCHETYPE_VERSION \
           -DgroupId="com.venia.cif" \
           -DartifactId="demo-store" \
-          -Dversion=1.0.0 \
+          -Dversion=${VENIA_STORE_VERSION} \
           -Dpackage="com.venia.cif" \
           -DappsFolderName="venia" \
           -DartifactName="Venia Demo Store" \
@@ -49,12 +49,12 @@ shared_steps:
         mv tmp/**/ghr ./ghr
         chmod +x ghr
 
-  - &deploy_github
+  - &deploy_github_prerelease
     run:
       name: Upload artifact to GitHub
       command: |
         ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
-        ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
+        ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n "Venia Demo Store Project" -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
 
   - &build_core_components
     run:
@@ -130,6 +130,7 @@ jobs:
     environment:
       MAVEN_OPTS: -Xmx3200m
       RELEASE_VERSION: latest
+      VENIA_STORE_VERSION: 1.0.0
 
     steps:
       - checkout
@@ -143,7 +144,7 @@ jobs:
       - *build_archetype
       - *build_all_package
       - *install_ghr
-      - *deploy_github
+      - *deploy_github_prerelease
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,6 @@ workflows:
           requires:
             - build-java-8
             - build-java-11
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             cd tmp
             curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz
             cd ..
-            mv mv ghr/**/ghr ./ghr
+            mv ghr/**/ghr ./ghr
             chmod +x ghr
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ jobs:
     <<: *shared
   
   build-sample-all:
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
     docker:
       - image: circleci/openjdk:11-jdk-stretch
 
@@ -103,7 +109,7 @@ jobs:
             mvn -B clean install
 
       - run: 
-          name: Generate all
+          name: Build All Package
           command: |
             ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
             mkdir -p venia-store
@@ -124,9 +130,26 @@ jobs:
               -DoptionAemVersion=6.5.0 \
               -DoptionIncludeExamples=y
             cd demo-store
-            mvn clean package # result in venia-store/demo-store/all/target/demo-store.all-*.zip
+            mvn clean package
+
+      - run:
+          name: Install GHR
+          command: |
+            mkdir -p tmp
+            cd tmp
+            curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz
+            cd ..
+            mv mv ghr/**/ghr ./ghr
+            chmod +x ghr
+
+      - run:
+          name: Upload artifact to GitHub
+          command: |
+            ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -prerelease -delete latest $ALL_PACKAGE
+
       - store_artifacts:
-          path: ./venia-store/demo-store/all/target/
+          path: ~/repo/venia-store/demo-store/all/target/
           destination: venia-store
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,114 +12,125 @@
 #
 ################################################################################
 
-version: 2
+version: 2.1
 
-shared_steps:
-  - &build_all_package
-    run: 
-      name: Build All Package
-      command: |
-        ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        mkdir -p venia-store
-        cd venia-store
-        mvn archetype:generate -B \
-          -DarchetypeGroupId="com.adobe.commerce.cif" \
-          -DarchetypeArtifactId="cif-project-archetype" \
-          -DarchetypeVersion=$ARCHETYPE_VERSION \
-          -DgroupId="com.venia.cif" \
-          -DartifactId="demo-store" \
-          -Dversion=${VENIA_STORE_VERSION} \
-          -Dpackage="com.venia.cif" \
-          -DappsFolderName="venia" \
-          -DartifactName="Venia Demo Store" \
-          -DcontentFolderName="venia" \
-          -DpackageGroup="venia" \
-          -DsiteName="Venia Demo Store" \
-          -DoptionAemVersion=6.5.0 \
-          -DoptionIncludeExamples=y
-        cd demo-store
-        mvn clean package
+commands:
+  deploy-all-package:
+    description: "Generate sample project from archetype and deploy all package to GitHub release"
+    parameters:
+      name:
+        type: string
+        default: "Venia Demo Store Project"
+    steps:
+      - run: 
+          name: Build All Package
+          command: |
+            ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            mkdir -p venia-store
+            cd venia-store
+            mvn archetype:generate -B \
+              -DarchetypeGroupId="com.adobe.commerce.cif" \
+              -DarchetypeArtifactId="cif-project-archetype" \
+              -DarchetypeVersion=$ARCHETYPE_VERSION \
+              -DgroupId="com.venia.cif" \
+              -DartifactId="demo-store" \
+              -Dversion=${VENIA_STORE_VERSION} \
+              -Dpackage="com.venia.cif" \
+              -DappsFolderName="venia" \
+              -DartifactName="Venia Demo Store" \
+              -DcontentFolderName="venia" \
+              -DpackageGroup="venia" \
+              -DsiteName="Venia Demo Store" \
+              -DoptionAemVersion=6.5.0 \
+              -DoptionIncludeExamples=y
+            cd demo-store
+            mvn clean package
+      - run:
+          name: Install ghr
+          command: |
+            mkdir -p tmp
+            curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz -C ./tmp
+            mv tmp/**/ghr ./ghr
+            chmod +x ghr
+      - run:
+          name: Upload artifact to GitHub
+          command: |
+            ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
+            ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n << parameters.name >> -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
 
-  - &install_ghr
-    run:
-      name: Install ghr
-      command: |
-        mkdir -p tmp
-        curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz -C ./tmp
-        mv tmp/**/ghr ./ghr
-        chmod +x ghr
+  build-archetype:
+    description: "Build and verify archetype"
+    steps:
+      - checkout
 
-  - &deploy_github_prerelease
-    run:
-      name: Upload artifact to GitHub
-      command: |
-        ALL_PACKAGE=$(find ./venia-store -iname 'demo-store.all-*.zip')
-        ./ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n "Venia Demo Store Project" -c ${CIRCLE_SHA1} -prerelease -delete $RELEASE_VERSION $ALL_PACKAGE
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            - v1-dependencies-
 
-  - &build_core_components
-    run:
-      name: Checkout and build CIF Core Components
-      command: |
-        git clone https://github.com/adobe/aem-core-cif-components.git
-        cd aem-core-cif-components
-        mvn -B clean install
-        cd ..
-        rm -rf aem-core-cif-components
+      - run:
+          name: Checkout and build CIF Core Components
+          command: |
+            git clone https://github.com/adobe/aem-core-cif-components.git
+            cd aem-core-cif-components
+            mvn -B clean install
+            cd ..
+            rm -rf aem-core-cif-components
 
-  - &build_archetype
-    run: 
-      name: Build Archetype
-      command: |
-        java -version
-        mvn -v
-        mvn -B integration-test
+      - run: 
+          name: Build Archetype
+          command: |
+            java -version
+            mvn -v
+            mvn -B integration-test
 
-shared_build: &shared_build
-  working_directory: ~/repo
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
 
-  environment:
-    MAVEN_OPTS: -Xmx3200m
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/surefire-reports/.*" -exec cp {} ~/test-results/junit/ \;
+          when: always
 
-  steps:
-    - checkout
+      - store_test_results:
+          path: ~/test-results
 
-    - restore_cache:
-        keys:
-          - v1-dependencies-{{ checksum "pom.xml" }}
-          - v1-dependencies-
-
-    - *build_core_components
-
-    - *build_archetype
-
-    - save_cache:
-        paths:
-          - ~/.m2
-        key: v1-dependencies-{{ checksum "pom.xml" }}
-
-    - run:
-        name: Save test results
-        command: |
-          mkdir -p ~/test-results/junit/
-          find . -type f -regex ".*/surefire-reports/.*" -exec cp {} ~/test-results/junit/ \;
-        when: always
-
-    - store_test_results:
-        path: ~/test-results
-
-    - store_artifacts:
-        path: ~/test-results/junit
+      - store_artifacts:
+          path: ~/test-results/junit
 
 jobs:
   build-java-8:
     docker:
       - image: circleci/openjdk:8u212-jdk-stretch
-    <<: *shared_build
+
+    working_directory: ~/repo
+
+    environment:
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - build-archetype
 
   build-java-11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
-    <<: *shared_build
+
+    working_directory: ~/repo
+
+    environment:
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - build-archetype
+
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - .m2/*
 
   deploy-sample-all:
     docker:
@@ -133,25 +144,10 @@ jobs:
       VENIA_STORE_VERSION: 1.0.0
 
     steps:
-      - checkout
+      - attach_workspace:
+          at: ~/
 
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "pom.xml" }}
-            - v1-dependencies-
-
-      - *build_core_components
-
-      - run: 
-          name: Build Archetype
-          command: |
-            java -version
-            mvn -v
-            mvn -B clean install -DskipTests
-
-      - *build_all_package
-      - *install_ghr
-      - *deploy_github_prerelease
+      - deploy-all-package
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,10 +136,8 @@ jobs:
           name: Install GHR
           command: |
             mkdir -p tmp
-            cd tmp
-            curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz
-            cd ..
-            mv ghr/**/ghr ./ghr
+            curl -L https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz | tar xvz -C ./tmp
+            mv tmp/**/ghr ./ghr
             chmod +x ghr
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,6 @@ workflows:
           requires:
             - build-java-8
             - build-java-11
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ shared_steps:
       command: |
         java -version
         mvn -v
-        mvn -B integration-test install
+        mvn -B integration-test
 
 shared_build: &shared_build
   working_directory: ~/repo
@@ -121,7 +121,7 @@ jobs:
       - image: circleci/openjdk:11-jdk-stretch
     <<: *shared_build
 
-  build-sample-all:
+  deploy-sample-all:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
 
@@ -141,7 +141,14 @@ jobs:
             - v1-dependencies-
 
       - *build_core_components
-      - *build_archetype
+
+      - run: 
+          name: Build Archetype
+          command: |
+            java -version
+            mvn -v
+            mvn -B clean install -DskipTests
+
       - *build_all_package
       - *install_ghr
       - *deploy_github_prerelease
@@ -152,4 +159,10 @@ workflows:
     jobs:
       - build-java-8
       - build-java-11
-      - build-sample-all
+      - deploy-sample-all:
+          requires: # Only deploy after tests passed
+            - build-java-8
+            - build-java-11
+#          filters: # Upload artifact only on master
+#            branches:
+#              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ shared_steps:
       command: |
         java -version
         mvn -v
-        mvn -B integration-test
+        mvn -B integration-test install
 
 shared_build: &shared_build
   working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
       - run: 
           name: Build All Package
           command: |
-            ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            ARCHETYPE_VERSION=$(< ~/version.txt)
             mkdir -p venia-store
             cd venia-store
             mvn archetype:generate -B \
@@ -83,6 +83,7 @@ commands:
             java -version
             mvn -v
             mvn -B integration-test
+            mvn help:evaluate -Dexpression=project.version -q -DforceStdout > ~/version.txt
 
       - save_cache:
           paths:
@@ -131,6 +132,7 @@ jobs:
           root: ~/
           paths:
             - .m2/*
+            - version.txt
 
   deploy-sample-all:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,58 @@ jobs:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
     <<: *shared
+  
+  build-sample-all:
+    docker:
+      - image: circleci/openjdk:11-jdk-stretch
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            - v1-dependencies-
+
+      - run:
+          name: Checkout and build CIF Core Components
+          command: |
+            git clone https://github.com/adobe/aem-core-cif-components.git
+            cd aem-core-cif-components
+            mvn -B clean install
+            cd ..
+            rm -rf aem-core-cif-components
+
+      - run: 
+          name: Build Archetype
+          command: |
+            mvn -B clean install
+
+      - run: 
+          name: Generate all
+          command: |
+            ARCHETYPE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            mkdir -p venia-store
+            cd venia-store
+            mvn archetype:generate -B \
+              -DarchetypeGroupId="com.adobe.commerce.cif" \
+              -DarchetypeArtifactId="cif-project-archetype" \
+              -DarchetypeVersion=$ARCHETYPE_VERSION \
+              -DgroupId="com.venia.cif" \
+              -DartifactId="demo-store" \
+              -Dversion=$ARCHETYPE_VERSION \
+              -Dpackage="com.venia.cif" \
+              -DappsFolderName="venia" \
+              -DartifactName="Venia Demo Store" \
+              -DcontentFolderName="venia" \
+              -DpackageGroup="venia" \
+              -DsiteName="Venia Demo Store" \
+              -DoptionAemVersion=6.5.0 \
+              -DoptionIncludeExamples=y
+            cd demo-store
+            mvn clean package # result in venia-store/demo-store/all/target/demo-store.all-*.zip
+      - store_artifacts:
+          path: ./venia-store/demo-store/all/target/
+          destination: venia-store
 
 workflows:
   version: 2
@@ -83,3 +135,4 @@ workflows:
     jobs:
       - build-java-8
       - build-java-11
+      - build-sample-all

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 ### IntelliJ ###
 .idea/
 *.iml
+
+venia-store/

--- a/README.md
+++ b/README.md
@@ -83,3 +83,6 @@ mvn archetype:generate \
 ```
      
 Side note: The profile "adobe-public" must be activated when using profiles like "autoInstallPackage" mentioned above.
+
+## Demo Project
+For demo purposes, we generate a sample project for the latest commit to the `master` branch. You can download the project in the [release](https://github.com/adobe/aem-cif-project-archetype/releases/tag/latest) section.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated CircleCI configuration to generate a sample project from the archetype for every commit on the `master` branch and upload the zip artifact from the all package to GitHub.

This artifact is for demo purposes **only**.

You can download the latest version under the `latest` tag in the [release](https://github.com/adobe/aem-cif-project-archetype/releases) section.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
