### PR TITLE
@trivial Fix typo in the CI configuration file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
               -DpackageGroup="venia" \
               -DsiteName="Venia Demo Store" \
               -DoptionAemVersion=6.5.0 \
-              -DoptionIncludeExamples=y
+              -DoptionIncludeExamples=y \
               -DoptionEmbedConnector=y
             cd demo-store
             mvn clean package


### PR DESCRIPTION

The CircleCI configuration has a missing `\` which causes the pipeline to fail

## Related Issue
N/A
## Motivation and Context

Unblock the pipeline

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
