### PR TITLE
CIF-1018 - The demo store generated from the archetype with custom parameters is missing styling

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/catalog-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/catalog-page/policies/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:lastModified="{Date}2019-07-23T09:43:35.548+02:00"
         cq:lastModifiedBy="admin"
-        cq:policy="venia/components/structure/catalogpage/policy_1563867800557"
+        cq:policy="${appsFolderName}/components/structure/catalogpage/policy_1563867800557"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/category-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/category-page/policies/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:lastModified="{Date}2019-03-26T14:31:52.676+02:00"
         cq:lastModifiedBy="admin"
-        cq:policy="venia/components/structure/page/policy_1563867489589"
+        cq:policy="${appsFolderName}/components/structure/page/policy_1563867489589"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/content-page/policies/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:lastModified="{Date}2018-10-17T11:19:19.105+02:00"
         cq:lastModifiedBy="admin"
-        cq:policy="venia/components/structure/page/policy_1563867489589"
+        cq:policy="${appsFolderName}/components/structure/page/policy_1563867489589"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/landing-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/landing-page/policies/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:lastModified="{Date}2019-03-13T22:32:00.962+02:00"
         cq:lastModifiedBy="admin"
-        cq:policy="venia/components/structure/page/policy_1563867489589"
+        cq:policy="${appsFolderName}/components/structure/page/policy_1563867489589"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/product-page/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/product-page/policies/.content.xml
@@ -5,7 +5,7 @@
     <jcr:content
         cq:lastModified="{Date}2019-03-26T14:31:52.676+02:00"
         cq:lastModifiedBy="admin"
-        cq:policy="venia/components/structure/page/policy_1563867489589"
+        cq:policy="${appsFolderName}/components/structure/page/policy_1563867489589"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/search-results/policies/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/search-results/policies/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:lastModified="{Date}2019-04-12T16:32:18.876+03:00"
         cq:lastModifiedBy="admin"
-        cq:policy="venia/components/structure/page/policy_1563867489589"
+        cq:policy="${appsFolderName}/components/structure/page/policy_1563867489589"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root


### PR DESCRIPTION
 * fixed the policy path in the templates to honor the appsFolderName property

<!--- Provide a general summary of your changes in the Title above -->

## Description

The default styling is not present for the demo store pages generated from the archetype with custom parameters, particularly when the appsFolderName property is not set to "venia".

## Related Issue

CIF-1018

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manually.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
