### PR TITLE
CIF-758 - Support for multiple category / product pages

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-__appsFolderName__.config
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-__appsFolderName__.config
@@ -1,0 +1,1 @@
+sling.filter.pattern="/content/${contentFolderName}/.*?/(category-page|product-page)"


### PR DESCRIPTION
## Description

Small addition to @cjelger PR for CIF-758 to add the required filter config for the "CIF page filter configuration" by default for the generated sample project.

Config is created in the projects config folder, for example: `/apps/testing/config/com.adobe.cq.commerce.core.components.internal.servlets.SpecificPageFilterFactory-testing.config`

<!--- Describe your changes in detail -->

## Related Issue

CIF-758

## Motivation and Context

Use the for multiple category / product pages for sample project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.