### PR TITLE
CIF-1059 - Both publishers showing lots of WARNS during Load test in …

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/policies/__appsFolderName__/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/policies/__appsFolderName__/.content.xml
@@ -4,19 +4,15 @@
     <components jcr:primaryType="nt:unstructured">
         <commerce jcr:primaryType="nt:unstructured">
             <productlist jcr:primaryType="nt:unstructured">
-                <v1 jcr:primaryType="nt:unstructured">
-                    <productlist jcr:primaryType="nt:unstructured">
-                        <default
-                            jcr:lastModified="{Date}2019-04-01T15:42:05.554+02:00"
-                            jcr:lastModifiedBy="admin"
-                            jcr:primaryType="nt:unstructured"
-                            jcr:title="AEM CIF Core Components Product List"
-                            sling:resourceType="wcm/core/components/policy/policy"
-                            showTitle="true">
-                            <jcr:content jcr:primaryType="nt:unstructured"/>
-                        </default>
-                    </productlist>
-                </v1>
+                <default
+                    jcr:lastModified="{Date}2019-04-01T15:42:05.554+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    jcr:title="AEM CIF Core Components Product List"
+                    sling:resourceType="wcm/core/components/policy/policy"
+                    showTitle="true">
+                    <jcr:content jcr:primaryType="nt:unstructured"/>
+                </default>
             </productlist>
         </commerce>
         <structure jcr:primaryType="nt:unstructured">


### PR DESCRIPTION
…logs

<!--- Provide a general summary of your changes in the Title above -->

Fix category page template policy to resolve "Probably misconfigured as it ends with '/settings'" warnings in error.log.

The product list on category template (https://github.com/adobe/aem-cif-project-archetype/blob/master/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/category-page/policies/.content.xml#L21) is configured to policy `${appsFolderName}/components/commerce/productlist/default`.

<!--- Describe your changes in detail -->

## Related Issue

CIF-1059

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.