### PR TITLE
CIF-1108 - Update WCM core components to 2.7.0

### DIFF
--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -40,7 +40,7 @@
         <sling.password>admin</sling.password>
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
-        <core.wcm.components.version>2.5.0</core.wcm.components.version>
+        <core.wcm.components.version>2.7.0</core.wcm.components.version>
         <core.cif.components.version>0.5.0</core.cif.components.version>
         <cif.connector.version>0.6.0</cif.connector.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The code scanning check in Cloudmanager (AMS) currently fails, because of an older (2.5.0) version of the WCM Core components which are embedded in the archetype all package. The issue was fixed in 2.7.0.

## How Has This Been Tested?

* Manually checked the CIF components that depend on WCM components.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
