### PR TITLE
CIF-1160 - fix parent release version of dispatcher pom.xml

### DIFF
--- a/.circleci/ci/deploy-ams.js
+++ b/.circleci/ci/deploy-ams.js
@@ -59,7 +59,7 @@ ci.dir('venia-store/cif-sample-project', () => {
 
     // Update dispatcher module pom.xml
     let dispatcherPom = fs.readFileSync("dispatcher/pom.xml", "utf8");
-    let versionRegEx = new RegExp("<version>\\d\\.\\d\\.\\d</version>");
+    let versionRegEx = new RegExp("<version>\\d+\\.\\d+\\.\\d+</version>");
     dispatcherPom = dispatcherPom.replace(versionRegEx, `<version>${releaseVersion}</version>`);
     fs.writeFileSync("dispatcher/pom.xml", dispatcherPom);
 

--- a/.circleci/ci/deploy-ams.js
+++ b/.circleci/ci/deploy-ams.js
@@ -57,6 +57,12 @@ ci.dir('venia-store/cif-sample-project', () => {
     projectPom = projectPom.replace('<module>samplecontent</module>', '<module>samplecontent</module>\n        <module>dispatcher</module>')
     fs.writeFileSync('pom.xml', projectPom);
 
+    // Update dispatcher module pom.xml
+    let dispatcherPom = fs.readFileSync("dispatcher/pom.xml", "utf8");
+    let versionRegEx = new RegExp("<version>\\d\\.\\d\\.\\d</version>");
+    dispatcherPom = dispatcherPom.replace(versionRegEx, `<version>${releaseVersion}</version>`);
+    fs.writeFileSync("dispatcher/pom.xml", dispatcherPom);
+
     // Change Magento root category id to 2
     const productsPomPath = 'samplecontent/src/main/content/jcr_root/content/venia/us/en/products/.content.xml';
     let productsContent = fs.readFileSync(productsPomPath, 'utf8');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes parent release version of dispatcher pom.xml maven submodule. Without this change, the build of the AMS sample project fails because the dispatcher pom.xml has an old parent version.

## Related Issue

CIF-1160

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
