### PR TITLE
CIF-1187 - fix cloud service configurations by adding missing config root folder

### DIFF
--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/cloudconfigs/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/cloudconfigs/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" 
+    jcr:primaryType="sling:Folder" />


### PR DESCRIPTION
## Description

Fix the ability to create cloud service configurations by adding missing config root folder.

## Related Issue

CIF-1187

## Motivation and Context

Cloud service configurations can not be created for Venia site

## How Has This Been Tested?

manually 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
