### PR TITLE
Avoid having "venia" in resource type

### DIFF
--- a/src/main/archetype/core/src/main/java/core/models/MyProductTeaserImpl.java
+++ b/src/main/archetype/core/src/main/java/core/models/MyProductTeaserImpl.java
@@ -33,7 +33,7 @@ import org.apache.sling.models.annotations.via.ResourceSuperType;
 @Model(adaptables = SlingHttpServletRequest.class, adapters = MyProductTeaser.class, resourceType = MyProductTeaserImpl.RESOURCE_TYPE)
 public class MyProductTeaserImpl implements MyProductTeaser {
 
-    protected static final String RESOURCE_TYPE = "venia/components/commerce/productteaser";
+    protected static final String RESOURCE_TYPE = "${appsFolderName}/components/commerce/productteaser";
 
     private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 


### PR DESCRIPTION
Minor change but if you don't use venia as the `appsFolderName` when generating the project the extension example won't work (and its a great example!)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
