### PR TITLE
Updated date calculation for "New"

### DIFF
--- a/src/main/archetype/core/src/main/java/core/models/MyProductTeaserImpl.java
+++ b/src/main/archetype/core/src/main/java/core/models/MyProductTeaserImpl.java
@@ -14,7 +14,7 @@
 package ${package}.core.models;
 
 import java.time.LocalDate;
-import java.time.Period;
+import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeFormatter;
 
 import javax.annotation.PostConstruct;
@@ -68,8 +68,7 @@ public class MyProductTeaserImpl implements MyProductTeaser {
             // compared to today
             final LocalDate createdAt = LocalDate.parse(productRetriever.fetchProduct().getCreatedAt(), formatter);
             if (createdAt != null) {
-                final Period period = Period.between(createdAt, LocalDate.now());
-                final int age = period.getDays();
+                final long age = ChronoUnit.DAYS.between(createdAt, LocalDate.now());
                 if (age < maxAgeProp) {
                     return true;
                 }

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/commerce/productteaser/_cq_dialog/.content.xml
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/commerce/productteaser/_cq_dialog/.content.xml
@@ -36,8 +36,7 @@
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield" 
                                                 fieldDescription="The maximum age in days the 'new' badge should be shown" 
                                                 fieldLabel="Max Product Age" 
-                                                name="./age" 
-                                                max="{Long}30" 
+                                                name="./age"
                                                 min="{Long}0" 
                                                 value="10" />
                                             <ageTypeHint jcr:primaryType="nt:unstructured" 


### PR DESCRIPTION
This is a minor change to the sample ProductTeaser extension and I know its sample code but it confused me when I was looking at the data in Magento.

The `isShowBadge()` logic calculated the number of days between when the product was created and the current date, but did not take into account Months and years. I.e if the created date was 2019-02-02 and the current date is 2020-02-012 the calculation would return 10 days when its actually 375...

see https://docs.oracle.com/javase/tutorial/datetime/iso/period.html

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.
