### PR TITLE
CIF-1251 - Add advanced pricing information to product teaser

### DIFF
--- a/src/main/archetype/core/src/main/java/core/models/MyProductTeaserImpl.java
+++ b/src/main/archetype/core/src/main/java/core/models/MyProductTeaserImpl.java
@@ -19,6 +19,7 @@ import java.time.format.DateTimeFormatter;
 
 import javax.annotation.PostConstruct;
 
+import com.adobe.cq.commerce.core.components.models.common.Price;
 import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
 
@@ -81,6 +82,9 @@ public class MyProductTeaserImpl implements MyProductTeaser {
     public String getFormattedPrice() {
         return productTeaser.getFormattedPrice();
     }
+
+    @Override
+    public Price getPriceRange() { return productTeaser.getPriceRange(); }
 
     @Override
     public String getImage() {

--- a/src/main/archetype/pom.xml
+++ b/src/main/archetype/pom.xml
@@ -42,8 +42,8 @@
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
         <core.wcm.components.version>2.7.0</core.wcm.components.version>
-        <core.cif.components.version>0.7.0</core.cif.components.version>
-        <cif.connector.version>0.8.0</cif.connector.version>
+        <core.cif.components.version>0.9.0</core.cif.components.version>
+        <cif.connector.version>0.9.0</cif.connector.version>
         <graphql.client.version>1.2.0</graphql.client.version>
         <magento.graphql.version>5.0.0-magento234</magento.graphql.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/productteaser/teaser.css
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/productteaser/teaser.css
@@ -45,7 +45,7 @@
     text-shadow: 2px 2px 4px rgba(0,0,0,0.9);
 }
 
-.productteaser .item__price {
+.productteaser .price {
     position: absolute;
     display: block;
     top: 45%;
@@ -54,6 +54,17 @@
     color: #ffffff;
     font-weight: 900;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.9);
+}
+
+.productteaser .price .regularPrice {
+    text-decoration: line-through;
+    font-size: 0.8rem;
+}
+
+.productteaser .price .discountedPrice {
+    font-weight: bold;
+    color: rgb(var(--venia-teal));
+    font-size: 1.2rem;
 }
 
 .productteaser .item__badge {

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/commerce/productteaser/productteaser.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/commerce/productteaser/productteaser.html
@@ -28,7 +28,7 @@
             </a>
             <a class="item__name" href=${symbol_dollar}{product.url}><span>${symbol_dollar}{product.name}</span></a>
             <sly data-sly-use.template="core/cif/components/commons/v1/price.html"
-                 data-sly-call="${template.price @ priceRange=product.priceRange, displayYouSave=false}"></sly>
+                 data-sly-call="${symbol_dollar}{template.price @ priceRange=product.priceRange, displayYouSave=false}"></sly>
             <sly data-sly-call="${symbol_dollar}{actionsTpl.actions @ product=product}"></sly>
         </div>
         <!--/* Condition if the product is not available, or invalid sku provided */-->

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/commerce/productteaser/productteaser.html
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/commerce/productteaser/productteaser.html
@@ -27,9 +27,8 @@
                 <img class="item__image" width="100%" height="100%" src="${symbol_dollar}{product.image}" alt="${symbol_dollar}{product.image}" />
             </a>
             <a class="item__name" href=${symbol_dollar}{product.url}><span>${symbol_dollar}{product.name}</span></a>
-            <div class="item__price">
-                <span> ${symbol_dollar}{product.formattedPrice} </span>
-            </div>
+            <sly data-sly-use.template="core/cif/components/commons/v1/price.html"
+                 data-sly-call="${template.price @ priceRange=product.priceRange, displayYouSave=false}"></sly>
             <sly data-sly-call="${symbol_dollar}{actionsTpl.actions @ product=product}"></sly>
         </div>
         <!--/* Condition if the product is not available, or invalid sku provided */-->


### PR DESCRIPTION
See https://github.com/adobe/aem-core-cif-components/pull/203.

* Updated CSS for product teaser pricing.
* Updated HTL overlay and Sling model of `MyProductTeaser`. (This only works with latest component version)

**Please only merge after components release.**