### PR TITLE
CIF-1246 - Fix CSS bug in searchbar

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/header/header-component.css
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/header/header-component.css
@@ -254,8 +254,8 @@
 }
 
 .fieldIcons__input > input {
-    padding-left: calc(1.875rem * var(--iconsBefore) + 0.375rem - 1px);
-    padding-right: calc(1.875rem * var(--iconsAfter) + 0.375rem - 1px);
+    padding-left: calc(1.875rem * var(--iconsBefore) - -0.375rem - 1px);
+    padding-right: calc(1.875rem * var(--iconsAfter) - -0.375rem - 1px);
 }
 
 .fieldIcons__before,

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/minicart/minicart.css
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/minicart/minicart.css
@@ -575,8 +575,8 @@
 }
 
 .fieldIcons__input > input {
-    padding-left: calc(1.875rem * var(--iconsBefore) + 0.375rem - 1px);
-    padding-right: calc(1.875rem * var(--iconsAfter) + 0.375rem - 1px);
+    padding-left: calc(1.875rem * var(--iconsBefore) - -0.375rem - 1px);
+    padding-right: calc(1.875rem * var(--iconsAfter) - -0.375rem - 1px);
 }
 
 .fieldIcons__before,

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/navigation/navigation-component.css
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/navigation/navigation-component.css
@@ -139,8 +139,8 @@
 }
 
 .fieldIcons__input > input {
-    padding-left: calc(1.875rem * var(--iconsBefore) + 0.375rem - 1px);
-    padding-right: calc(1.875rem * var(--iconsAfter) + 0.375rem - 1px);
+    padding-left: calc(1.875rem * var(--iconsBefore) - -0.375rem - 1px);
+    padding-right: calc(1.875rem * var(--iconsAfter) - -0.375rem - 1px);
 }
 
 .fieldIcons__before,

--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/product/product.css
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/components/product/product.css
@@ -284,8 +284,8 @@
 }
 
 .fieldIcons__input > input {
-    padding-left: calc(1.875rem * var(--iconsBefore) + 0.375rem - 1px);
-    padding-right: calc(1.875rem * var(--iconsAfter) + 0.375rem - 1px);
+    padding-left: calc(1.875rem * var(--iconsBefore) - -0.375rem - 1px);
+    padding-right: calc(1.875rem * var(--iconsAfter) - -0.375rem - 1px);
 }
 
 .fieldIcons__before,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* YUI minification in AEM breaks CSS `calc` by removing whitespaces which are needed. This results in a faulty display of the venia searchbar in the header.
* See JIRA issue for more context.

## How Has This Been Tested?

* Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.
