### PR TITLE
CIF-1238 - Zooming out browser does not resize images of product list…

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/common/common.css
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/clientlibs/theme/common/common.css
@@ -42,6 +42,12 @@ body {
     padding: 0;
 }
 
+div.header + div.responsivegrid {
+    margin: 0 auto;
+    max-width: 1500px !important;
+    float: none !important;
+}
+
 body,
 input,
 select,


### PR DESCRIPTION
… component

- make sure that the content div shrinks when the browser viewport is "zoomed out"
- header and footer use entire width (see discussion in JIRA issue)

## How Has This Been Tested?

Manually in generated project, see screenshots with 100% and 50% zoom.

## Screenshots (if appropriate):

![Screenshot 2020-02-20 at 16 32 33](https://user-images.githubusercontent.com/24548615/74950514-8452b480-53ff-11ea-9262-d3b02dfbb4da.png)

![Screenshot 2020-02-20 at 16 34 06](https://user-images.githubusercontent.com/24548615/74950523-89176880-53ff-11ea-90c6-7c2351e730bc.png)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
