### PR TITLE
CIF-1256 - Better customizable PLP/PDP URL generation

### DIFF
--- a/src/main/archetype/samplecontent/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/samplecontent/src/main/content/META-INF/vault/filter.xml
@@ -3,4 +3,5 @@
     <filter root="/content/${contentFolderName}" mode="update"/>
     <filter root="/content/dam/${contentFolderName}" mode="update"/>
     <filter root="/apps/${appsFolderName}/config" mode="update"/>
+    <filter root="/etc/map.publish" mode="update"/>
 </workspaceFilter>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/apps/__appsFolderName__/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/apps/__appsFolderName__/config/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
@@ -1,0 +1,6 @@
+productUrlTemplate="${page}.${url_key}.html#${variant_sku}"
+productIdentifierLocation="SELECTOR"
+productIdentifierType="URL_KEY"
+categoryUrlTemplate="${page}.${id}.html/${url_path}"
+categoryIdentifierLocation="SELECTOR"
+categoryIdentifierType="ID"

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"
+    hidden="true"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page-reverse/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/category-page\\.(\\d+)\\.html/(.+)"
+    sling:match="$1/$2/$4.$3.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page-reverse/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/category-page\\.(\\d+)\\.html/(.+)"
-    sling:match="$1/$2/$4.$3.html"/>
+    sling:match="content/venia/$1/$2/$4.$3.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/$1/$2/products/category-page.$4.html/$3"
-    sling:match="([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>
+    sling:match="content/venia/([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/category-page/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/$1/$2/products/category-page.$4.html/$3"
+    sling:match="([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page-reverse/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/product-page\\.(.+)"
+    sling:match="$1/$2/$3"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page-reverse/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/product-page\\.(.+)"
-    sling:match="$1/$2/$3"/>
+    sling:match="content/venia/$1/$2/$3"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/$1/$2/products/product-page.$3.html"
+    sling:match="([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.4503/product-page/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/$1/$2/products/product-page.$3.html"
-    sling:match="([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>
+    sling:match="content/venia/([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page-reverse/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/category-page\\.(\\d+)\\.html/(.+)"
+    sling:match="$1/$2/$4.$3.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page-reverse/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/category-page\\.(\\d+)\\.html/(.+)"
-    sling:match="$1/$2/$4.$3.html"/>
+    sling:match="content/venia/$1/$2/$4.$3.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/$1/$2/products/category-page.$4.html/$3"
-    sling:match="([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>
+    sling:match="content/venia/([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/category-page/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/$1/$2/products/category-page.$4.html/$3"
+    sling:match="([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page-reverse/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/product-page\\.(.+)"
+    sling:match="$1/$2/$3"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page-reverse/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page-reverse/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/product-page\\.(.+)"
-    sling:match="$1/$2/$3"/>
+    sling:match="content/venia/$1/$2/$3"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/$1/$2/products/product-page.$3.html"
+    sling:match="([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/etc/map.publish/http/localhost.80/product-page/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/$1/$2/products/product-page.$3.html"
-    sling:match="([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>
+    sling:match="content/venia/([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>


### PR DESCRIPTION
## Description

This PR configures an example `UrlProvider` service and the corresponding Sling Mappings for an AEM publish instance on ports `4503` or `80` (that is, when accessed via Dispatcher). Note that the Sling Mappings are created in `/etc/map.publish` to void that they are activated by default on author or publish instances. To activate them on a publish instance, one simply needs to rename the folder to `/etc/map` (it's also possible to configure `/etc/map.publish` in the "Apache Sling Resource Resolver Factory" AEM config but this triggers an avalanche of service restarts ...).

This configures the Venia sample website to generate the following links WITHOUT and WITH Sling Mappings.

**Product pages**
`/content/venia/us/en/products/product-page.zing-jump-rope.html` vs. `/us/en/zing-jump-rope.html`

**Category pages**
`/content/venia/us/en/products/category-page.5.html/gear/fitness-equipment` vs. `/us/en/gear/fitness-equipment.5.html`

It's an example configuration to demonstrate how the `UrlProvider` and the Sling Mappings can be used to configure SEO-friendly pages. The documentation will be added to the Core Components wiki page.

## How Has This Been Tested?

Manually tested + unit tests in the CIF components repo.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
