### PR TITLE
CIF-1438 - Reloading a PLP results in "No resource found" error

### DIFF
--- a/src/main/archetype/samplecontent/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/samplecontent/src/main/content/META-INF/vault/filter.xml
@@ -3,6 +3,7 @@
     <filter root="/content/${contentFolderName}" mode="update"/>
     <filter root="/content/dam/${contentFolderName}" mode="update"/>
     <filter root="/apps/${appsFolderName}/config" mode="update"/>
+    <filter root="/apps/${appsFolderName}/config.publish" mode="update"/>
     <filter root="/etc/map.publish" mode="update"/>
     <filter root="/var/commerce/products" mode="update"/>
 </workspaceFilter>

--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/apps/__appsFolderName__/config.publish/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/apps/__appsFolderName__/config.publish/com.adobe.cq.commerce.core.components.internal.services.UrlProviderImpl.config
@@ -1,6 +1,6 @@
 productUrlTemplate="{{page}}.{{url_key}}.html#{{variant_sku}}"
 productIdentifierLocation="SELECTOR"
 productIdentifierType="URL_KEY"
-categoryUrlTemplate="{{page}}.{{id}}.html"
+categoryUrlTemplate="{{page}}.{{id}}.html/{{url_path}}"
 categoryIdentifierLocation="SELECTOR"
 categoryIdentifierType="ID"

--- a/src/main/archetype/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/src/main/archetype/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -3,5 +3,6 @@
     <filter root="/apps/${appsFolderName}">
         <exclude pattern="/apps/${appsFolderName}/install" />
         <exclude pattern="/apps/${appsFolderName}/config" />
+        <exclude pattern="/apps/${appsFolderName}/config.publish" />
     </filter>
 </workspaceFilter>


### PR DESCRIPTION
- remove url_path suffix from category urls on author instance
- create a dedicated config for publish instance to keep the suffix so we can still demo the rewrite rules with Sling mappings
- update URL template formats to new version

## Description

The `url_path` suffix in category URLs is problematic in the "preview" mode on author instances, because the URL ends up having two suffixes.

## How Has This Been Tested?

Manually tested on author and publish instances.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
