### PR TITLE
CIF-1406: Search results template fix

### DIFF
--- a/src/main/archetype/samplecontent/src/main/content/jcr_root/content/__contentFolderName__/us/en/search/.content.xml
+++ b/src/main/archetype/samplecontent/src/main/content/jcr_root/content/__contentFolderName__/us/en/search/.content.xml
@@ -7,7 +7,7 @@
         cq:lastModifiedBy="admin"
         cq:lastRolledout="{Date}2019-04-17T13:22:08.551+02:00"
         cq:lastRolledoutBy="admin"
-        cq:template="/conf/${confFolderName}/settings/wcm/templates/content-page"
+        cq:template="/conf/${confFolderName}/settings/wcm/templates/search-results"
         jcr:mixinTypes="[cq:LiveRelationship]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Search Results"

--- a/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/search-results/structure/.content.xml
+++ b/src/main/archetype/ui.content/src/main/content/jcr_root/conf/__confFolderName__/settings/wcm/templates/search-results/structure/.content.xml
@@ -46,18 +46,6 @@
                 <searchbar jcr:primaryType="nt:unstructured"
                            sling:resourceType="${appsFolderName}/components/commerce/searchbar"/>
             </header>
-            <product-list-container
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="wcm/foundation/components/responsivegrid">
-                <productlist
-                        jcr:created="{Date}2019-03-26T14:33:35.239+02:00"
-                        jcr:createdBy="admin"
-                        jcr:lastModified="{Date}2019-03-26T14:33:35.239+02:00"
-                        jcr:lastModifiedBy="admin"
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="${appsFolderName}/components/commerce/productlist"
-                        editable="{Boolean}true"/>
-            </product-list-container>
             <responsivegrid
                     jcr:created="{Date}2018-10-17T10:18:24.968+02:00"
                     jcr:createdBy="admin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `search-results` template included an additional `container` with a `productlist` child in it's structure.
This made pages created with this template render 2 `productcollections`

Also, the us->en default search page was using `/conf/${confFolderName}/settings/wcm/templates/content-page` instead of `/conf/${confFolderName}/settings/wcm/templates/search-results` as template path
## Related Issue

CIF-1406

## How Has This Been Tested?

Manually

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/6639076/85288200-0af6cb80-b49e-11ea-8c61-751a2d76aef3.png)

After:
![image](https://user-images.githubusercontent.com/6639076/85288322-34aff280-b49e-11ea-98d5-8e2ce9e4662e.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.
